### PR TITLE
正文分隔符过滤思考内容

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -10,11 +10,17 @@
     ]
   },
   "filtered_prefixes": {
-    "type": "list",
+    "type": "list", 
     "description": "要过滤的无标签文本行前缀",
     "hint": "在此添加要过滤的文本行前缀，例如 'Thinking:' 或 'Pondering:'。插件会移除以此处文本开头的、直到空行或结尾的整个文本块。",
     "default": [
       "Thinking:"
     ]
+  },
+  "content_separator": {
+    "type": "string",
+    "description": "正文分隔符",
+    "hint": "用于分隔思考内容和正文的特殊字符，例如 '@@@'。插件会删除此分隔符前的所有内容，只保留分隔符后的正文。",
+    "default": "@@@"
   }
 }

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ from astrbot.api.star import Context, Star, register
 class FilterthinktagsPlugin(Star):
     def __init__(self, context: Context, config: AstrBotConfig):
         super().__init__(context)
+        # 将传入的配置对象保存在插件实例中
         self.config = config
 
     @filter.on_decorating_result()
@@ -15,36 +16,36 @@ class FilterthinktagsPlugin(Star):
         result = event.get_result()
         chain = result.chain
 
+        # 从配置中读取两个列表，如果配置不存在则使用空列表作为默认值
         tags_to_filter = self.config.get('filtered_tags', [])
         prefixes_to_filter = self.config.get('filtered_prefixes', [])
-        separator = self.config.get('content_separator', '')
+        # 从配置中读取分隔符，如果配置不存在则使用 "@@@" 作为默认值
+        separator = self.config.get('content_separator', '@@@')
 
         new_chain = []
         for component in chain:
+            # 只处理纯文本消息段
             if isinstance(component, Plain):
                 new_text = component.text
                 
-                # 只有当配置了分隔符时才进行分隔符过滤
-                if separator:
-                    if separator in new_text:
-                        # 找到最后一个分隔符的位置
-                        last_separator_index = new_text.rfind(separator)
-                        # 保留最后一个分隔符之后的内容
-                        new_text = new_text[last_separator_index + len(separator):]
-                    else:
-                        # 如果没有找到分隔符，清空文本
-                        new_text = ""
+                # 使用分隔符过滤思考内容
+                if separator and separator in new_text:
+                    # 找到最后一个分隔符的位置
+                    last_separator_index = new_text.rfind(separator)
+                    # 保留最后一个分隔符之后的内容
+                    new_text = new_text[last_separator_index + len(separator):]
 
                 # 根据标签列表动态过滤标签
-                if tags_to_filter and new_text:
+                if tags_to_filter:
                     tag_group = '|'.join(re.escape(tag) for tag in tags_to_filter)
                     pattern = rf'<({tag_group})>.*?</\1>\s*'
                     new_text = re.sub(pattern, '', new_text, flags=re.DOTALL)
 
                 # 过滤无标签的、可能跨行的文本块
-                if prefixes_to_filter and new_text:
+                if prefixes_to_filter:
                     for prefix in prefixes_to_filter:
                         pattern = rf'^{re.escape(prefix)}.*?(\n\n|\Z)'
+                        # 使用 re.DOTALL (让.匹配换行符) 和 re.MULTILINE (让^匹配每行开头)
                         new_text = re.sub(pattern, '', new_text, flags=re.DOTALL | re.MULTILINE)
                 
                 # 清理文本两端的空白字符
@@ -53,7 +54,7 @@ class FilterthinktagsPlugin(Star):
                 if stripped_text:
                     new_chain.append(Plain(stripped_text))
             else:
-                # 如果不是纯文本组件，则原样保留
+                # 如果不是纯文本组件（如图片、at等），则原样保留
                 new_chain.append(component)
 
         # 用处理过的新消息链替换旧的消息链

--- a/main.py
+++ b/main.py
@@ -8,7 +8,6 @@ from astrbot.api.star import Context, Star, register
 class FilterthinktagsPlugin(Star):
     def __init__(self, context: Context, config: AstrBotConfig):
         super().__init__(context)
-        # 将传入的配置对象保存在插件实例中
         self.config = config
 
     @filter.on_decorating_result()
@@ -16,38 +15,36 @@ class FilterthinktagsPlugin(Star):
         result = event.get_result()
         chain = result.chain
 
-        # 从配置中读取两个列表，如果配置不存在则使用空列表作为默认值
         tags_to_filter = self.config.get('filtered_tags', [])
         prefixes_to_filter = self.config.get('filtered_prefixes', [])
+        separator = self.config.get('content_separator', '@@@')
 
         new_chain = []
         for component in chain:
-            # 只处理纯文本消息段
             if isinstance(component, Plain):
                 new_text = component.text
                 
+                # 使用分隔符过滤思考内容
+                if separator and separator in new_text:
+                    last_separator_index = new_text.rfind(separator)
+                    new_text = new_text[last_separator_index + len(separator):]
 
-                # 根据标签列表动态过滤标签
+                # 原有的标签过滤
                 if tags_to_filter:
                     tag_group = '|'.join(re.escape(tag) for tag in tags_to_filter)
                     pattern = rf'<({tag_group})>.*?</\1>\s*'
                     new_text = re.sub(pattern, '', new_text, flags=re.DOTALL)
 
-                # 过滤无标签的、可能跨行的文本块
+                # 原有的前缀过滤
                 if prefixes_to_filter:
                     for prefix in prefixes_to_filter:
                         pattern = rf'^{re.escape(prefix)}.*?(\n\n|\Z)'
-                        # 使用 re.DOTALL (让.匹配换行符) 和 re.MULTILINE (让^匹配每行开头)
                         new_text = re.sub(pattern, '', new_text, flags=re.DOTALL | re.MULTILINE)
                 
-                # 清理文本两端的空白字符
                 stripped_text = new_text.strip()
-                # 只有当处理后的文本不为空时，才将其添加回新的消息链
                 if stripped_text:
                     new_chain.append(Plain(stripped_text))
             else:
-                # 如果不是纯文本组件（如图片、at等），则原样保留
                 new_chain.append(component)
 
-        # 用处理过的新消息链替换旧的消息链
         result.chain = new_chain

--- a/main.py
+++ b/main.py
@@ -8,7 +8,6 @@ from astrbot.api.star import Context, Star, register
 class FilterthinktagsPlugin(Star):
     def __init__(self, context: Context, config: AstrBotConfig):
         super().__init__(context)
-        # 将传入的配置对象保存在插件实例中
         self.config = config
 
     @filter.on_decorating_result()
@@ -16,36 +15,36 @@ class FilterthinktagsPlugin(Star):
         result = event.get_result()
         chain = result.chain
 
-        # 从配置中读取两个列表，如果配置不存在则使用空列表作为默认值
         tags_to_filter = self.config.get('filtered_tags', [])
         prefixes_to_filter = self.config.get('filtered_prefixes', [])
-        # 从配置中读取分隔符，如果配置不存在则使用 "@@@" 作为默认值
-        separator = self.config.get('content_separator', '@@@')
+        separator = self.config.get('content_separator', '')
 
         new_chain = []
         for component in chain:
-            # 只处理纯文本消息段
             if isinstance(component, Plain):
                 new_text = component.text
                 
-                # 使用分隔符过滤思考内容
-                if separator and separator in new_text:
-                    # 找到最后一个分隔符的位置
-                    last_separator_index = new_text.rfind(separator)
-                    # 保留最后一个分隔符之后的内容
-                    new_text = new_text[last_separator_index + len(separator):]
+                # 只有当配置了分隔符时才进行分隔符过滤
+                if separator:
+                    if separator in new_text:
+                        # 找到最后一个分隔符的位置
+                        last_separator_index = new_text.rfind(separator)
+                        # 保留最后一个分隔符之后的内容
+                        new_text = new_text[last_separator_index + len(separator):]
+                    else:
+                        # 如果没有找到分隔符，清空文本
+                        new_text = ""
 
                 # 根据标签列表动态过滤标签
-                if tags_to_filter:
+                if tags_to_filter and new_text:
                     tag_group = '|'.join(re.escape(tag) for tag in tags_to_filter)
                     pattern = rf'<({tag_group})>.*?</\1>\s*'
                     new_text = re.sub(pattern, '', new_text, flags=re.DOTALL)
 
                 # 过滤无标签的、可能跨行的文本块
-                if prefixes_to_filter:
+                if prefixes_to_filter and new_text:
                     for prefix in prefixes_to_filter:
                         pattern = rf'^{re.escape(prefix)}.*?(\n\n|\Z)'
-                        # 使用 re.DOTALL (让.匹配换行符) 和 re.MULTILINE (让^匹配每行开头)
                         new_text = re.sub(pattern, '', new_text, flags=re.DOTALL | re.MULTILINE)
                 
                 # 清理文本两端的空白字符
@@ -54,7 +53,7 @@ class FilterthinktagsPlugin(Star):
                 if stripped_text:
                     new_chain.append(Plain(stripped_text))
             else:
-                # 如果不是纯文本组件（如图片、at等），则原样保留
+                # 如果不是纯文本组件，则原样保留
                 new_chain.append(component)
 
         # 用处理过的新消息链替换旧的消息链

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ from astrbot.api.star import Context, Star, register
 class FilterthinktagsPlugin(Star):
     def __init__(self, context: Context, config: AstrBotConfig):
         super().__init__(context)
+        # 将传入的配置对象保存在插件实例中
         self.config = config
 
     @filter.on_decorating_result()
@@ -15,36 +16,46 @@ class FilterthinktagsPlugin(Star):
         result = event.get_result()
         chain = result.chain
 
+        # 从配置中读取两个列表，如果配置不存在则使用空列表作为默认值
         tags_to_filter = self.config.get('filtered_tags', [])
         prefixes_to_filter = self.config.get('filtered_prefixes', [])
+        # 从配置中读取分隔符，如果配置不存在则使用 "@@@" 作为默认值
         separator = self.config.get('content_separator', '@@@')
 
         new_chain = []
         for component in chain:
+            # 只处理纯文本消息段
             if isinstance(component, Plain):
                 new_text = component.text
                 
                 # 使用分隔符过滤思考内容
                 if separator and separator in new_text:
+                    # 找到最后一个分隔符的位置
                     last_separator_index = new_text.rfind(separator)
+                    # 保留最后一个分隔符之后的内容
                     new_text = new_text[last_separator_index + len(separator):]
 
-                # 原有的标签过滤
+                # 根据标签列表动态过滤标签
                 if tags_to_filter:
                     tag_group = '|'.join(re.escape(tag) for tag in tags_to_filter)
                     pattern = rf'<({tag_group})>.*?</\1>\s*'
                     new_text = re.sub(pattern, '', new_text, flags=re.DOTALL)
 
-                # 原有的前缀过滤
+                # 过滤无标签的、可能跨行的文本块
                 if prefixes_to_filter:
                     for prefix in prefixes_to_filter:
                         pattern = rf'^{re.escape(prefix)}.*?(\n\n|\Z)'
+                        # 使用 re.DOTALL (让.匹配换行符) 和 re.MULTILINE (让^匹配每行开头)
                         new_text = re.sub(pattern, '', new_text, flags=re.DOTALL | re.MULTILINE)
                 
+                # 清理文本两端的空白字符
                 stripped_text = new_text.strip()
+                # 只有当处理后的文本不为空时，才将其添加回新的消息链
                 if stripped_text:
                     new_chain.append(Plain(stripped_text))
             else:
+                # 如果不是纯文本组件（如图片、at等），则原样保留
                 new_chain.append(component)
 
+        # 用处理过的新消息链替换旧的消息链
         result.chain = new_chain


### PR DESCRIPTION
添加正文分隔符过滤思考内容，专门针对思考内容一点特殊格式都没有的ai
人格设置中让ai在每句回复前添加特殊符号，查找最后一个特殊符号，连同特殊符号前的所有内容过滤